### PR TITLE
Update perform-search.js to also include all the indexing APIs so they can be called with an API Token instead of just through the admin UI.

### DIFF
--- a/server/src/routes/perform-search.js
+++ b/server/src/routes/perform-search.js
@@ -9,6 +9,24 @@ module.exports = {
         config: { 
             policies: []
         },
-      }
+      },
+      {
+        method: 'GET',
+        path: '/reindex',
+        handler: 'performIndexing.rebuildIndex',
+        config: { policies: [] },
+      },
+      {
+        method: 'GET',
+        path: '/collection-reindex/:collectionname',
+        handler: 'performIndexing.indexCollection',
+        config: { policies: [] },
+      },
+      {
+        method: 'GET',
+        path: '/trigger-indexing/',
+        handler: 'performIndexing.triggerIndexingTask',
+        config: { policies: [] },
+      },
     ],
   };


### PR DESCRIPTION
More details can be found here: https://github.com/geeky-biz/strapi-plugin-elasticsearch/issues/9

I have tested the above with patch-package in my local instance and it works as expected.

![image](https://github.com/user-attachments/assets/189b039f-0bfa-4150-9bb5-c12b27b62d14)
